### PR TITLE
More options for specific use cases and fixed an issue regarding the "archiveDirectory" input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The action leverages Unreal Engine's `RunUAT.bat` script, providing a flexible i
 -   `UPROJECT_PATH`: Full path to your Unreal Engine project `.uproject` file.
 -   `BUILD_CONFIG`: Build configuration to use, e.g., `Development` or `Shipping`.
 -   `PLATFORM`: Target platform for your build, such as `Win64` or `Linux`.
+-   `CLEAN`: Set to `true` to have your project cleaned before rebuild (default: `false`).
 -   `COOK`: Set to `true` to include cooking in the build process.
 -   `STAGE`: Set to `true` to stage your project.
 -   `PACKAGE`: Set to `true` to execute the packaging process.
@@ -22,11 +23,12 @@ The action leverages Unreal Engine's `RunUAT.bat` script, providing a flexible i
 -   `SERVER`: Set to `true` to include a dedicated server in your build.
 -   `ARCHIVE`: Set to `true` to archive the build output.
 -   `ARCHIVE_PATH`: Specify the path where the archive should be stored (used only if `ARCHIVE` is `true`).
+-   `NULLRHI`: Set to `true` if you don't have a video output (i.e. a screen) such as when running this action in a container on the cloud (default: `false`).
 -   `EDITOR` : Set to true to compile the editor as well. Useful for builds requiring editor functionality.
 -   `ENCRYPT_INI`: Set to `true` to encrypt INI files.
 -   `RELEASE`: Enter new release version number to create a release version.
 -   `PATCH`: Enter the base release version number to generate a patch.
--   `MAPS`: Comma separated list of maps to build and package.
+-   `MAPS`: Comma separated list of maps to build and package, leave empty to build all maps.
 
 ## Using the Action
 
@@ -40,6 +42,7 @@ Include this action in your workflow by adding it as a step in your `.github/wor
     UPROJECT_PATH: ${{ github.workspace }}/YourGameFolder/MyGame.uproject
     BUILD_CONFIG: Development
     PLATFORM: Win64
+    CLEAN: true
     COOK: true
     STAGE: true
     PACKAGE: false
@@ -47,6 +50,7 @@ Include this action in your workflow by adding it as a step in your `.github/wor
     SERVER: false
     ARCHIVE: false
     ARCHIVE_PATH: 'C:/Archives/MyGame'
+    NULLRHI: true
     EDITOR: true
     ENCRYPT_INI: true
     RELEASE: '1.0.0'

--- a/action.yaml
+++ b/action.yaml
@@ -105,7 +105,7 @@ runs:
         $stageArg = if ($stage -eq 'true') { "-stage" } else { "" }
         $pakArg = if ($pak -eq 'true') { "-pak" } else { "" }
         $packageArg = if ($package -eq 'true') { "-package" } else { "" }
-        $archiveArg = if ($archive -eq 'true') { "-archive -archivedirectory=$archivePath" } else { "" }
+        $archiveArg = if ($archive -eq 'true') { "-archive -archivedirectory=`"$archivePath`"" } else { "" }
         $nullrhiArg = if ($nullrhi -eq 'true') { "-nullrhi" } else { "" }
         $editorArg = if ($archive -eq 'true') { "-nocompileeditor" } else { "" }
         $encryptIniArg = if ($encryptIni -eq 'true') { "-encryptinifiles" } else { "" }

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
   PLATFORM:
     description: 'Platform to build for'
     required: true
+  CLEAN:
+    description: 'Whether to clean'
+    required: false
+    default: 'false'
   COOK:
     description: 'Whether to cook'
     required: false
@@ -46,6 +50,10 @@ inputs:
   ARCHIVE_PATH:
     description: 'Archive Path'
     required: false
+  NULLRHI:
+    description: 'Whether to execute commands without video output'
+    required: false
+    default: 'false'
   EDITOR:
     description: 'Whether to compile the editor as well'
     required: false
@@ -63,9 +71,10 @@ inputs:
     required: false
     default: 'false'
   MAPS:
-    description: 'Maps to build and package (comma separated list of maps)'
+    description: 'Maps to build and package (comma separated list of maps, leave empty for all maps)'
     required: false
-  
+    default: 'true'
+
 runs:
   using: 'composite'
   steps:
@@ -75,6 +84,7 @@ runs:
         $uprojectPath = "${{ inputs.UPROJECT_PATH }}"
         $buildConfig = "${{ inputs.BUILD_CONFIG }}"
         $platform = "${{ inputs.PLATFORM }}"
+        $clean = "${{ inputs.CLEAN }}"
         $server = "${{ inputs.SERVER }}"
         $cook = "${{ inputs.COOK }}"
         $stage = "${{ inputs.STAGE }}"
@@ -82,27 +92,31 @@ runs:
         $package = "${{ inputs.PACKAGE }}"
         $archive = "${{ inputs.ARCHIVE }}"
         $archivePath = "${{ inputs.ARCHIVE_PATH }}"
+        $nullrhi = "${{ inputs.NULLRHI }}"
         $editor = "${{ inputs.EDITOR }}"
         $encryptIni = "${{ inputs.ENCRYPT_INI }}"
         $release = "${{ inputs.RELEASE }}"
         $patch = "${{ inputs.PATCH }}"
         $maps = "${{ inputs.MAPS }}"
-  
+
+        $cleanArg = if ($clean -eq 'true') { "-clean" } else { "" }
         $serverArg = if ($server -eq 'true') { "-server -serverplatform=$platform -noclient" } else { "" }
         $cookArg = if ($cook -eq 'true') { "-cook" } else { "" }
         $stageArg = if ($stage -eq 'true') { "-stage" } else { "" }
         $pakArg = if ($pak -eq 'true') { "-pak" } else { "" }
         $packageArg = if ($package -eq 'true') { "-package" } else { "" }
         $archiveArg = if ($archive -eq 'true') { "-archive -archivedirectory=$archivePath" } else { "" }
+        $nullrhiArg = if ($nullrhi -eq 'true') { "-nullrhi" } else { "" }
         $editorArg = if ($archive -eq 'true') { "-nocompileeditor" } else { "" }
         $encryptIniArg = if ($encryptIni -eq 'true') { "-encryptinifiles" } else { "" }
         $releaseArg = if ($release -ne 'false') { "-createreleaseversion=$release" } else { "" }
         $patchArg = if ($patch -ne 'false') { "-generatepatch -basedonreleaseversion=$patch" } else { "" }
-  
+        $mapsArg = if ($maps -eq 'true') { "" } else { "-map=$maps" }
+
         $command = "& `"$runUatPath`" BuildCookRun " +
                   "-project=`"$uprojectPath`" " +
-                  "-clientconfig=$buildConfig -serverconfig=$buildConfig -platform=$platform -map=$maps " +
-                  "$serverArg $cookArg $stageArg $pakArg $packageArg $archiveArg $editorArg $encryptIniArg $releaseArg $patchArg " +
-                  "-noP4 -build -unattended -utf8output -prereqs"
-        
+                  "-clientconfig=$buildConfig -serverconfig=$buildConfig -platform=$platform $mapsArg " +
+                  "$cleanArg $serverArg $cookArg $stageArg $pakArg $packageArg $archiveArg $editorArg $encryptIniArg $releaseArg $patchArg " +
+                  "-noP4 -build -unattended -utf8output -prereqs $nullrhiArg"
+
         Invoke-Expression $command


### PR DESCRIPTION
### TL;DR

Hi,
I wanted to use your Github Action for my project but ended up having to tweak a few things to my use cases. The changes shouldn't impact current action usage but allow for a wider variety of situations (including mine), therefore I think a PR is in order to complement your Action instead of creating a similar yet different one.

### Features

- **New `CLEAN` input parameter:** I added a `CLEAN` input that translates to the `-clean` flag in the `RunUAT` command. This lets the user clean the solution therefore transforming the `build` into a `rebuild`. This helped me overcome an issue when running the action after a plugin update where the simple `build` option would leave some targets out-of-date which spawned some errors whereas with `-clean` it worked fine. Defaults to `false` so it doesn't impact current action usage.
- **New `NULLRHI` input parameter:** I added a `NULLRHI` input that translates to the `-nullrhi` flag in the `RunUAT` command. The flag is needed when running the `RunUAT` on a device that doesn't have a video output. This is useful in my case because I'm running my jobs in containers on the cloud and on my on-prem server which both lack video output. Even when jobs run on my personal machine I like to disable video output to keep them in the background so it doesn't disrupt my work too much. Defaults to `false` so it doesn't impact current action usage.
- **Changed default value for maps:** I set a default value for the maps so a user could withdraw from specifying any map and the `RunUAT` command would build all maps. On smaller projects, prototypes or game jams this becomes useful because there's only a few maps to build so it's easier not to have to type them (prevents typos and such). The default value for the `maps` input translates to basically no command flag related to maps for the `RunUAT` command which therefore builds everything.

### Fixes

- **`ARCHIVE_PATH` may now contain spaces:** Due to the way this parameter was escaped, the `ARCHIVE_PATH` directory could not contain spaces. I simply recycled the syntax you used to escape the `RUNUAT_PATH` and the `UPROJECT_PATH` and applied it to the `ARCHIVE_PATH` input parameter.

### Possible improvements

- **Linux support:** I really like the legibility of this action compared to just running the command by itself. I would love to use it for Linux as well though I would not know how to proceed as I'm quite new to the Actions framework. I would think a `linux` branch in the repo would work with basically the same script but running a `shell` instead of a `powershell`. Don't know how clean this looks to you though, what do you think?
- **PDB deletion:** For some reason the `RunUAT` command still exports the PDB symbols files when running in `Shipping` mode, which take some valuable storage space in the repository. What I'm usually doing when packaging for `Shipping` is removing these PDB files with a one-liner command. This could be a `DELETE_PDB` input parameter to the action though it would mean the action does more than just running the `RunUAT` command, which is why I didn't include it in my PR since this is quite an important change from your original Action.
- **Folder compression:** In the same category as the PDB deletion, I usually follow up my archive creation with a folder compression command to create a ZIP file or a tarball of said archive. This could be a `ZIP_ARCHIVE` input or something, but again didn't want to change your action too much without your input first.

### Misc

- **Updated README:** Of course I updated the README with the new parameters that I'm suggesting so they're correctly documented.

### Conclusion

Thank you for creating this little action which is a smooth entry into the world of Github Actions and CI/CD for Unreal Engine. I hope you'll accept the request so that we may continue to use a single action for this purpose instead of duplicating functionality in the Action marketplace. I look forward to getting your advice on the possible improvements listed above.

Cheers,